### PR TITLE
Fix a bug for a particulary wpml setting

### DIFF
--- a/wpml-comments-merging.php
+++ b/wpml-comments-merging.php
@@ -28,6 +28,8 @@ function merge_comments($comments, $post_ID) {
 		// in $comments are already the comments from the current language
 		if(!$l['active']) {
 			$otherID = apply_filters( 'wpml_object_id', $post_ID, $type, false, $l['language_code'] );
+			if ($otherID === null)
+                		continue;
 			$othercomments = get_comments( array('post_id' => $otherID, 'status' => 'approve', 'order' => 'ASC') );
 			$comments = array_merge($comments, $othercomments);
 		}


### PR DESCRIPTION
Continue the loop if the variable $otherID is null on the merge_comments function. 
This can happen if the post type translation is set to 'translatable - use translation if available or fallback to default language' on the wpml settings page.
In this case, the get_comments function returns all comments from all posts.